### PR TITLE
feat: pass id to input

### DIFF
--- a/components/tag-input.tsx
+++ b/components/tag-input.tsx
@@ -118,7 +118,8 @@ export interface TagInputProps extends OmittedInputProps, VariantProps<typeof ta
 
 const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
 
-    const { 
+    const {
+        id,
         placeholder, 
         tags, 
         setTags, 
@@ -293,6 +294,7 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>((props, ref) 
                 <>
                     <Input
                         ref={inputRef}
+                        id={id}
                         type="text"
                         placeholder={maxTags !== undefined && tags.length >= maxTags ? placeholderWhenFull : placeholder}
                         value={inputValue}


### PR DESCRIPTION
## Background
Using this component with the [Shadcn UI Form](https://ui.shadcn.com/docs/components/form) won't autofocus the input when clicking the label.

## Solution
Passing the `id` to the input prop will help.

![RHM ScreenShot 2023-10-17 at 13 52 19](https://github.com/JaleelB/shadcn-tag-input/assets/7524911/38eee39d-f125-4aab-abc0-f5afa6008a39)

## DEMO

![RHM ScreenShot 2023-10-17 at 13 55 25](https://github.com/JaleelB/shadcn-tag-input/assets/7524911/c11bf25f-6844-482e-a5d7-805c7bed3c96)
