### PR TITLE
update snippets content about autocomplete

### DIFF
--- a/content/snippets/autocomplete.mdx
+++ b/content/snippets/autocomplete.mdx
@@ -34,7 +34,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
   children,
 }) => {
   return (
-    <Command className="border">
+    <Command className="border min-w-[400px]">
       {children}
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
@@ -42,6 +42,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
           {autocompleteOptions.map((option) => (
             <CommandItem key={option.id}>
               <div
+                className="w-full"
                 onClick={() => {
                   if (maxTags && tags.length >= maxTags) return;
                   if (


### PR DESCRIPTION
Issue Addressed:
Resolved an issue where the clickable area for auto-complete was too small when copying component code from snippets.

Description:
Upon investigating the issue, it was discovered that the auto-complete feature's clickable area was insufficient when copying component code from snippets. Upon attempting to update the codespace, it was noticed that while the component itself was successfully updated, the snippet content did not reflect the changes.

PS: I only change the autocomplete snippet and haven't check others.