### PR TITLE
Backspace will remove most recent tag if current input is empty

### DIFF
--- a/packages/emblor/src/tag/tag-input.tsx
+++ b/packages/emblor/src/tag/tag-input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
 import { type VariantProps } from 'class-variance-authority';
@@ -157,6 +157,14 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>((props, ref) 
     // error
     return null;
   }
+
+  useEffect(() => {
+      if (inputValue === "") {
+        setActiveTagIndex(tags.length - 1);
+      } else {
+        setActiveTagIndex(null);
+      }
+    }, [inputValue]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;


### PR DESCRIPTION
Added a useEffect to update activeTagIndex so that if you backspace when the current input is empty it will delete the most recent tag. Before my commit, to use the backspace to remove an item, you would have to use the arrow key to move to the left tag and then delete it. My implementation allows the user to delete the most recent tag as long as the current topic they are typing in is empty. 