### PR TITLE
fix: add rounded-md to inlineTagsContainer when set enableAutocomplete

### DIFF
--- a/packages/emblor/src/tag/tag-input.tsx
+++ b/packages/emblor/src/tag/tag-input.tsx
@@ -545,7 +545,7 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>((props, ref) 
               ) : (
                 <div
                   className={cn(
-                    `flex flex-row flex-wrap items-center p-2 gap-2 h-fit w-full bg-background text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50`,
+                    `flex flex-row flex-wrap items-center p-2 gap-2 h-fit rounded-md w-full bg-background text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50`,
                     styleClasses?.inlineTagsContainer,
                   )}
                 >


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/81056ccb-5a5b-41fd-ac65-f6d4ea47c081)
after:
![image](https://github.com/user-attachments/assets/c62c58df-8d7b-418d-b656-8ddd9900fd2b)
#93 