### PR TITLE
feat: Custom 'Sugestions' and 'No found results.' texts in autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ type TagInputProps = {
   // List of autocomplete options.
   autocompleteOptions?: Array<{ id: string; text: string }>; // default: []
 
+  // Title displayed for the autocomplete suggestions.
+  autoCompleteTitle?: string; // default: "Suggestions"
+
+  // Message displayed when no autocomplete results are found.
+  autoCompleteNotFound?: string; // default: "No results found."
+
   // Maximum number of tags allowed.
   maxTags?: number; // default: null
 

--- a/packages/emblor/README.md
+++ b/packages/emblor/README.md
@@ -151,6 +151,12 @@ type TagInputProps = {
   // List of autocomplete options.
   autocompleteOptions?: Array<{ id: string; text: string }>; // default: []
 
+  // Title displayed for the autocomplete suggestions.
+  autoCompleteTitle?: string; // default: "Suggestions"
+
+  // Message displayed when no autocomplete results are found.
+  autoCompleteNotFound?: string; // default: "No results found."
+
   // Maximum number of tags allowed.
   maxTags?: number; // default: null
 

--- a/packages/emblor/src/tag/autocomplete.tsx
+++ b/packages/emblor/src/tag/autocomplete.tsx
@@ -19,6 +19,8 @@ type AutocompleteProps = {
   inlineTags?: boolean;
   classStyleProps: TagInputStyleClassesProps['autoComplete'];
   usePortal?: boolean;
+  autocompleteTitle?: string;
+  autocompleteNotFound?: string;
 };
 
 export const Autocomplete: React.FC<AutocompleteProps> = ({
@@ -27,6 +29,8 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
   setInputValue,
   setTagCount,
   autocompleteOptions,
+  autocompleteTitle = 'Suggestions',
+  autocompleteNotFound = 'No results found.',
   maxTags,
   onTagAdd,
   onTagRemove,
@@ -251,7 +255,9 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
                   minHeight: '68px',
                 }}
               >
-                <span className="text-muted-foreground font-medium text-sm py-1.5 px-2 pb-2">Suggestions</span>
+                <span className="text-muted-foreground font-medium text-sm py-1.5 px-2 pb-2">
+                  {autocompleteTitle}
+                </span>
                 <div role="separator" className="py-0.5" />
                 {autocompleteOptions.map((option, index) => {
                   const isSelected = index === selectedIndex;
@@ -292,7 +298,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
                 })}
               </div>
             ) : (
-              <div className="py-6 text-center text-sm">No results found.</div>
+              <div className="py-6 text-center text-sm">{autocompleteNotFound}</div>
             )}
           </div>
         </PopoverContent>

--- a/packages/emblor/src/tag/tag-input.tsx
+++ b/packages/emblor/src/tag/tag-input.tsx
@@ -55,6 +55,8 @@ export interface TagInputProps extends OmittedInputProps, VariantProps<typeof ta
   setTags: React.Dispatch<React.SetStateAction<Tag[]>>;
   enableAutocomplete?: boolean;
   autocompleteOptions?: Tag[];
+  autocompleteTitle?: string;
+  autocompleteNotFound?: string;
   maxTags?: number;
   minTags?: number;
   readOnly?: boolean;
@@ -107,6 +109,8 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>((props, ref) 
     shape,
     enableAutocomplete,
     autocompleteOptions,
+    autocompleteNotFound = "No results found.",
+    autocompleteTitle = "Suggestions",
     maxTags,
     delimiter = Delimiter.Comma,
     onTagAdd,
@@ -489,6 +493,8 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>((props, ref) 
             setTags={setTags}
             setInputValue={setInputValue}
             autocompleteOptions={filteredAutocompleteOptions as Tag[]}
+            autocompleteNotFound={autocompleteNotFound}
+            autocompleteTitle={autocompleteTitle}
             setTagCount={setTagCount}
             maxTags={maxTags}
             onTagAdd={onTagAdd}

--- a/website/components/tag/autocomplete.tsx
+++ b/website/components/tag/autocomplete.tsx
@@ -6,6 +6,8 @@ type AutocompleteProps = {
   tags: TagType[];
   setTags: React.Dispatch<React.SetStateAction<TagType[]>>;
   autocompleteOptions: TagType[];
+  autocompleteTitle?: string;
+  autocompleteNotFound?: string;
   maxTags?: number;
   onTagAdd?: (tag: string) => void;
   allowDuplicates: boolean;
@@ -16,6 +18,8 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
   tags,
   setTags,
   autocompleteOptions,
+  autocompleteNotFound = "No results found.",
+  autocompleteTitle = "Suggestions",
   maxTags,
   onTagAdd,
   allowDuplicates,
@@ -25,8 +29,8 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     <Command className="border min-w-[400px]">
       {children}
       <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
-        <CommandGroup heading="Suggestions">
+        <CommandEmpty>{autocompleteNotFound}</CommandEmpty>
+        <CommandGroup heading={autocompleteTitle}>
           {autocompleteOptions.map((option) => (
             <CommandItem key={option.id}>
               <div

--- a/website/components/tag/tag-input.tsx
+++ b/website/components/tag/tag-input.tsx
@@ -29,6 +29,8 @@ export interface TagInputProps extends OmittedInputProps, VariantProps<typeof ta
   setTags: React.Dispatch<React.SetStateAction<Tag[]>>;
   enableAutocomplete?: boolean;
   autocompleteOptions?: Tag[];
+  autocompleteTitle?: string;
+  autocompleteNotFound?: string;
   maxTags?: number;
   minTags?: number;
   readOnly?: boolean;
@@ -75,6 +77,8 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>((props, ref) 
     className,
     enableAutocomplete,
     autocompleteOptions,
+    autocompleteNotFound = 'No results found.',
+    autocompleteTitle = "Suggestions",
     maxTags,
     delimiter = Delimiter.Comma,
     onTagAdd,
@@ -249,6 +253,8 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>((props, ref) 
             tags={tags}
             setTags={setTags}
             autocompleteOptions={filteredAutocompleteOptions as Tag[]}
+            autocompleteNotFound={autocompleteNotFound}
+            autocompleteTitle={autocompleteTitle}
             maxTags={maxTags}
             onTagAdd={onTagAdd}
             allowDuplicates={allowDuplicates ?? false}

--- a/website/content/docs/api-reference.mdx
+++ b/website/content/docs/api-reference.mdx
@@ -358,6 +358,20 @@ return (
       <TableCell>No</TableCell>
     </TableRow>
     <TableRow>
+      <TableCell className="border-r">autocompleteTitle</TableCell>
+      <TableCell className="border-r">"Suggestions"</TableCell>
+      <TableCell className="border-r">string</TableCell>
+      <TableCell className="border-r">Title displayed for the autocomplete suggestions.</TableCell>
+      <TableCell>No</TableCell>
+    </TableRow>
+    <TableRow>
+      <TableCell className="border-r">autocompleteNotFound</TableCell>
+      <TableCell className="border-r">"No results found."</TableCell>
+      <TableCell className="border-r">string</TableCell>
+      <TableCell className="border-r">Message displayed when no autocomplete results are found.</TableCell>
+      <TableCell>No</TableCell>
+    </TableRow>
+    <TableRow>
       <TableCell className="border-r">restrictTagsToAutocompleteOptions</TableCell>
       <TableCell className="border-r">false</TableCell>
       <TableCell className="border-r">boolean</TableCell>

--- a/website/utils/utils.ts
+++ b/website/utils/utils.ts
@@ -37,6 +37,18 @@ export const tagInputProps: propOption[] = [
     description: 'List of options for autocomplete. Must be used with enableAutocomplete.',
   },
   {
+    option: 'autocompleteTitle',
+    type: 'string',
+    default: '"Suggestions"',
+    description: 'Title displayed for the autocomplete suggestions.',
+  },
+  {
+    option: 'autocompleteNotFound',
+    type: 'string',
+    default: '"No results found."',
+    description: 'Message displayed when no autocomplete results are found.',
+  },
+  {
     option: 'maxTags',
     type: 'number',
     default: 'null',


### PR DESCRIPTION
This PR introduces customization options for the 'title' and 'no results found' texts in the autocomplete. This allows users to easily configure these messages.
